### PR TITLE
효율성 증가를 위한 코드 변경

### DIFF
--- a/src/main/java/com/example/kjy_test_backend/board/BoardService.java
+++ b/src/main/java/com/example/kjy_test_backend/board/BoardService.java
@@ -34,8 +34,9 @@ public class BoardService {
     }
 
     public CommentDto.CommentResponse registerComment(CommentDto.CommentRegister dto, Long boardIdx) {
-        Board board = boardRepository.findById(boardIdx).orElseThrow();
+        Board board = boardRepository.getReferenceById(boardIdx);
         Comment comment = commentRepository.save(dto.toEntity(board));
         return CommentDto.CommentResponse.from(comment);
     }
+
 }

--- a/src/main/java/com/example/kjy_test_backend/board/model/BoardDto.java
+++ b/src/main/java/com/example/kjy_test_backend/board/model/BoardDto.java
@@ -52,14 +52,14 @@ public class BoardDto {
         private Long idx;
         private String title;
         private String writer;
-        private List<CommentDto.CommentResponse> comments;
+        private int commentCount;
 
         public static BoardListResponse from(Board board) {
             return BoardListResponse.builder()
                     .idx(board.getIdx())
                     .title(board.getTitle())
                     .writer(board.getWriter())
-                    .comments(board.getComments().stream().toList().stream().map(CommentDto.CommentResponse::from).collect(Collectors.toList()))
+                    .commentCount(board.getComments().size())
                     .build();
         }
     }


### PR DESCRIPTION
게시글의 목록을 출력할 때 댓글의 수만 출력 하도록 변경(게시글 목록 기능 확인 완료)
댓글 작성시 쿼리문 효율적으로 작성되도록 변경